### PR TITLE
Add RequestLogMiddleware for structured access logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,4 +500,132 @@ app itself.
 whenever OpenTelemetry has populated them on the log record. So if you later add tracing
 (running the app under `opentelemetry-instrument` with the `OTEL_*` environment variables),
 your Collector-shipped logs automatically correlate with traces in SigNoz — no in-app log
-exporter and no change to harry required.
+exporter and no change to harry required. See "Request logging & tracing" below for the
+full setup.
+
+## Request logging & tracing
+
+harry can log one structured access line per request and — with OpenTelemetry — tie every
+log line to a distributed trace that spans reverse proxy, app server, and Django.
+
+**Required vs. optional.** Everything in this section beyond the middleware itself is an
+optional enhancer, not a prerequisite:
+
+| Tool | Required? | Notes |
+|---|---|---|
+| OpenTelemetry | No | With it, every log line carries `trace_id` and links to its trace in SigNoz. Without it, the middleware still logs fully. No OpenTelemetry package is a dependency of harry. |
+| Caddy | No | Any reverse proxy, or none. Caddy's `tracing` is only needed for proxy↔app trace correlation. |
+| gunicorn | No | Any WSGI/ASGI server. The snippet below is just an example of surfacing `traceparent` at the server layer. |
+| SigNoz / OTel Collector | No | harry only writes JSON to stdout; shipping it anywhere is a deployment choice. |
+
+### Access logging
+
+Add the middleware to `MIDDLEWARE`, after `AuthenticationMiddleware` (it reads
+`request.user`):
+
+```python
+MIDDLEWARE = [
+    # ...
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # ...
+    "harry.middleware.RequestLogMiddleware",
+]
+```
+
+Each request emits one line at `INFO` on the `harry.request` logger — readable in
+development (`GET /invoices/42 200 (12ms)`), structured in production:
+
+```json
+{"ts": "…", "level": "INFO", "logger": "harry.request", "msg": "GET /invoices/42 200 (12ms)",
+ "method": "GET", "path": "/invoices/42", "status": 200, "duration_ms": 12, "user_id": 7}
+```
+
+Field notes:
+
+- `duration_ms` measures middleware entry to response return — for streaming responses
+  that is time-to-headers, not time-to-last-byte.
+- `user_id` is the authenticated user's primary key, else `null`.
+- Client IP, user agent, and response size are deliberately absent — your reverse proxy's
+  access log owns those. The query string is also excluded: it's the classic place
+  password-reset tokens and magic links leak into logs. The request id concept is absent
+  too — when tracing is on, `trace_id` is the per-request id on every line.
+
+There is no on/off setting: membership in `MIDDLEWARE` is the switch. To silence access
+lines in one environment without touching `MIDDLEWARE`, raise the logger's level:
+
+```python
+LOGGING = build_logging_config(
+    extra_loggers={"harry.request": {"level": "WARNING", "handlers": ["console"], "propagate": False}},
+)
+```
+
+#### Ignoring noise endpoints
+
+Requests whose path is in `REQUEST_LOG_IGNORE_PATHS` get no access line. Entries ending
+in `/` match as path prefixes; all other entries match exactly — never by substring, so
+an entry can't silently swallow a real route. The default:
+
+```python
+REQUEST_LOG_IGNORE_PATHS = {
+    "/favicon.ico",
+    "/robots.txt",
+    "/apple-touch-icon.png",
+    "/apple-touch-icon-precomposed.png",
+    "/.well-known/",   # trailing slash → prefix match
+}
+```
+
+Healthcheck paths are deliberately *not* ignored: a probe every 30 seconds is a useful
+status/latency heartbeat in SigNoz. If you find it too chatty, add your healthcheck path
+to the set (overriding replaces the default set wholesale).
+
+### Correlating logs with traces
+
+Enable OpenTelemetry's Django and logging instrumentation and every log line — access
+lines included — carries the request's `trace_id`/`span_id`, which harry's JSON formatter
+emits and SigNoz uses to link logs to traces. The quickest path today:
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install   # detects Django etc. and installs instrumentations
+```
+
+```bash
+OTEL_SERVICE_NAME=myapp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod \
+OTEL_PYTHON_LOG_CORRELATION=true \
+opentelemetry-instrument gunicorn myproject.wsgi
+```
+
+`OTEL_PYTHON_LOG_CORRELATION=true` is the piece that stamps trace ids onto log records;
+without it you get traces but uncorrelated logs.
+
+### One trace across the full lifecycle
+
+For the proxy, app server, and Django to share a single trace id, the proxy must *join
+the trace*. With Caddy, that's the `tracing` directive:
+
+```
+example.com {
+    tracing
+    reverse_proxy 127.0.0.1:8000
+}
+```
+
+Caddy continues an inbound W3C trace context or starts a new trace, exports its own span
+(honoring the standard `OTEL_EXPORTER_OTLP_*` / `OTEL_SERVICE_NAME` env vars), injects
+`traceparent` into the proxied request — so Django's instrumentation continues the same
+trace — and stamps `traceID`/`spanID` onto its own access logs. The result in SigNoz:
+Caddy's span, Django's spans, and every app log line share one trace id.
+
+To also surface the id in gunicorn's access log:
+
+```python
+# gunicorn.conf.py
+access_log_format = '%(h)s "%(r)s" %(s)s %(b)s %(D)sus traceparent=%({traceparent}i)s'
+```
+
+**Caveat:** without Caddy `tracing` (or another tracing proxy), the trace originates in
+Django — requests still trace and logs still correlate, but the proxy hop is not part of
+the trace. "One id, full lifecycle" specifically requires the proxy to participate.

--- a/src/harry/middleware.py
+++ b/src/harry/middleware.py
@@ -1,0 +1,109 @@
+"""Request access logging middleware.
+
+Adds one structured access line per request. Correlation with traces is not handled
+here: when OpenTelemetry's logging instrumentation is active it stamps trace ids onto
+every log record, and :class:`harry.logconfig.JSONFormatter` promotes them to
+``trace_id``/``span_id`` JSON keys. This middleware deliberately mints no request id.
+"""
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
+from django.conf import settings
+from django.http import HttpRequest
+from django.http.response import HttpResponseBase
+
+logger = logging.getLogger("harry.request")
+
+# Endpoints that generate traffic no one investigates. Healthcheck paths are absent on
+# purpose: their access lines are a useful status/latency heartbeat in SigNoz.
+DEFAULT_REQUEST_LOG_IGNORE_PATHS = frozenset(
+    {
+        "/favicon.ico",
+        "/robots.txt",
+        "/apple-touch-icon.png",
+        "/apple-touch-icon-precomposed.png",
+        "/.well-known/",
+    }
+)
+
+GetResponse = Callable[[HttpRequest], HttpResponseBase]
+AsyncGetResponse = Callable[[HttpRequest], Awaitable[HttpResponseBase]]
+
+
+class RequestLogMiddleware:
+    """Log one access line per request at INFO on the ``harry.request`` logger.
+
+    Presence in ``MIDDLEWARE`` is the only switch. Place it after
+    ``AuthenticationMiddleware`` so ``request.user`` is populated. To silence access
+    lines in an environment without touching ``MIDDLEWARE``, raise the
+    ``harry.request`` logger's level via ``build_logging_config(extra_loggers=...)``.
+
+    The ``REQUEST_LOG_IGNORE_PATHS`` setting (default
+    :data:`DEFAULT_REQUEST_LOG_IGNORE_PATHS`) suppresses lines for noise endpoints.
+    Entries ending in ``/`` match as path prefixes; all other entries must match the
+    path exactly — never by substring, so an entry cannot silently swallow a real
+    route.
+
+    ``duration_ms`` measures middleware entry to response return; for streaming
+    responses that is time-to-headers, not time-to-last-byte.
+    """
+
+    sync_capable = True
+    async_capable = True
+
+    def __init__(self, get_response: GetResponse | AsyncGetResponse) -> None:
+        self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
+
+    def __call__(
+        self, request: HttpRequest
+    ) -> HttpResponseBase | Awaitable[HttpResponseBase]:
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        start = time.monotonic()
+        response = self.get_response(request)
+        self._log(request, response, start)  # type: ignore[arg-type]
+        return response  # type: ignore[return-value]
+
+    async def _acall(self, request: HttpRequest) -> HttpResponseBase:
+        start = time.monotonic()
+        response = await self.get_response(request)  # type: ignore[misc]
+        self._log(request, response, start)
+        return response
+
+    def _log(
+        self, request: HttpRequest, response: HttpResponseBase, start: float
+    ) -> None:
+        if self._ignored(request.path):
+            return
+        duration_ms = round((time.monotonic() - start) * 1000)
+        user = getattr(request, "user", None)
+        user_id = user.pk if user is not None and user.is_authenticated else None
+        logger.info(
+            "%s %s %s (%dms)",
+            request.method,
+            request.path,
+            response.status_code,
+            duration_ms,
+            extra={
+                "method": request.method,
+                "path": request.path,
+                "status": response.status_code,
+                "duration_ms": duration_ms,
+                "user_id": user_id,
+            },
+        )
+
+    @staticmethod
+    def _ignored(path: str) -> bool:
+        ignore = getattr(
+            settings, "REQUEST_LOG_IGNORE_PATHS", DEFAULT_REQUEST_LOG_IGNORE_PATHS
+        )
+        return any(
+            path.startswith(entry) if entry.endswith("/") else path == entry
+            for entry in ignore
+        )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,175 @@
+import asyncio
+import logging
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse, StreamingHttpResponse
+from django.test import RequestFactory
+
+from harry.middleware import DEFAULT_REQUEST_LOG_IGNORE_PATHS, RequestLogMiddleware
+
+from . import factories
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture
+def capture(caplog):
+    caplog.set_level(logging.INFO, logger="harry.request")
+    return caplog
+
+
+def run(request, *, status=200, response=None):
+    """Send a request through the middleware with a stub view."""
+    response = response if response is not None else HttpResponse(status=status)
+    middleware = RequestLogMiddleware(lambda r: response)
+    return middleware(request)
+
+
+def access_records(caplog):
+    return [r for r in caplog.records if r.name == "harry.request"]
+
+
+# Access line content
+
+
+def test_logs_one_info_line_on_harry_request_logger(rf, capture):
+    run(rf.get("/invoices/42"))
+    (record,) = access_records(capture)
+    assert record.levelno == logging.INFO
+    assert record.getMessage().startswith("GET /invoices/42 200 (")
+    assert record.getMessage().endswith("ms)")
+
+
+def test_extra_fields(rf, capture):
+    run(rf.post("/invoices/"), status=201)
+    (record,) = access_records(capture)
+    assert record.method == "POST"
+    assert record.path == "/invoices/"
+    assert record.status == 201
+    assert isinstance(record.duration_ms, int)
+    assert record.duration_ms >= 0
+    assert record.user_id is None
+
+
+def test_user_id_for_authenticated_user(rf, capture):
+    user = factories.user_create()
+    request = rf.get("/")
+    request.user = user
+    run(request)
+    (record,) = access_records(capture)
+    assert record.user_id == user.pk
+
+
+def test_user_id_none_for_anonymous_user(rf, capture):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+    run(request)
+    (record,) = access_records(capture)
+    assert record.user_id is None
+
+
+def test_user_id_none_without_auth_middleware(rf, capture):
+    # No request.user attribute at all must not raise.
+    run(rf.get("/"))
+    (record,) = access_records(capture)
+    assert record.user_id is None
+
+
+def test_error_responses_are_logged(rf, capture):
+    run(rf.get("/boom"), status=500)
+    (record,) = access_records(capture)
+    assert record.status == 500
+
+
+def test_streaming_response_logged_at_headers_time(rf, capture):
+    response = StreamingHttpResponse(iter([b"a", b"b"]))
+    run(rf.get("/export"), response=response)
+    (record,) = access_records(capture)
+    assert record.status == 200
+
+
+# Ignore paths
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/favicon.ico",
+        "/robots.txt",
+        "/apple-touch-icon.png",
+        "/apple-touch-icon-precomposed.png",
+        "/.well-known/security.txt",
+        "/.well-known/acme-challenge/token",
+    ],
+)
+def test_default_noise_paths_are_not_logged(rf, capture, path):
+    run(rf.get(path))
+    assert access_records(capture) == []
+
+
+def test_healthcheck_paths_are_logged(rf, capture):
+    run(rf.get("/health/"))
+    (record,) = access_records(capture)
+    assert record.path == "/health/"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/favicon.ico/nested",  # exact entries do not match as prefixes
+        "/static/robots.txt",  # and never as substrings
+        "/well-known",  # prefix entries require the full prefix
+    ],
+)
+def test_matching_is_never_substring(rf, capture, path):
+    run(rf.get(path))
+    (record,) = access_records(capture)
+    assert record.path == path
+
+
+def test_ignore_paths_overridable_via_setting(rf, capture, settings):
+    settings.REQUEST_LOG_IGNORE_PATHS = {"/health/", "/internal/"}
+    run(rf.get("/health/"))
+    run(rf.get("/internal/probe"))
+    run(rf.get("/favicon.ico"))  # default set no longer applies
+    (record,) = access_records(capture)
+    assert record.path == "/favicon.ico"
+
+
+def test_default_ignore_set_contents():
+    assert DEFAULT_REQUEST_LOG_IGNORE_PATHS == {
+        "/favicon.ico",
+        "/robots.txt",
+        "/apple-touch-icon.png",
+        "/apple-touch-icon-precomposed.png",
+        "/.well-known/",
+    }
+
+
+# Async
+
+
+def test_async_get_response(rf, capture):
+    async def get_response(request):
+        return HttpResponse()
+
+    middleware = RequestLogMiddleware(get_response)
+    response = asyncio.run(middleware(rf.get("/async")))
+    assert response.status_code == 200
+    (record,) = access_records(capture)
+    assert record.path == "/async"
+    assert record.method == "GET"
+
+
+def test_middleware_marked_coroutine_only_for_async_chain(rf):
+    from asgiref.sync import iscoroutinefunction
+
+    async def async_get_response(request):
+        return HttpResponse()
+
+    assert iscoroutinefunction(RequestLogMiddleware(async_get_response))
+    assert not iscoroutinefunction(RequestLogMiddleware(lambda r: HttpResponse()))


### PR DESCRIPTION
Closes #4.

## What

- **`harry.middleware.RequestLogMiddleware`** — one `INFO` line per request on the dedicated `harry.request` logger: human-readable `msg` (`GET /invoices/42 200 (12ms)`) plus structured `method`, `path`, `status`, `duration_ms`, `user_id` fields, which `JSONFormatter` lifts to top-level JSON keys in production.
- **`REQUEST_LOG_IGNORE_PATHS`** — suppresses noise endpoints; default `{/favicon.ico, /robots.txt, /apple-touch-icon.png, /apple-touch-icon-precomposed.png, /.well-known/}`. Trailing-slash entries match as prefixes, everything else exactly — never by substring. Healthchecks are deliberately logged as a status/latency heartbeat.
- **README: "Request logging & tracing"** — middleware setup and placement (after `AuthenticationMiddleware`), silencing per environment via `extra_loggers`, enabling OTel log↔trace correlation (`OTEL_PYTHON_LOG_CORRELATION=true`), the Caddy `tracing` + gunicorn `traceparent` recipe for one trace id across proxy → app server → Django (verified against Caddy's tracing module source), the no-proxy-tracing caveat, and a required-vs-optional table (OTel/Caddy/gunicorn/SigNoz are enhancers, not prerequisites).

## Design notes (per #4)

- **No request id machinery.** With OTel logging instrumentation active, every record already carries `trace_id`/`span_id` via the existing formatter promotion; a harry-minted id would duplicate it. No ContextVar, no filter, no header trust/echo.
- **Membership in `MIDDLEWARE` is the only switch** — no settings toggle. The dedicated logger name provides the finer-grained, per-environment off-switch.
- Excluded fields: client IP / user agent / response size (the proxy access log owns them) and query string (token-leak vector).
- Sync- and async-capable via the standard asgiref coroutine-marking pattern; `duration_ms` is time-to-headers for streaming responses (documented).

## Testing

- 21 new tests: access-line content and logger identity, `user_id` for authenticated/anonymous/no-auth-middleware requests, 500 and streaming responses, exact + prefix + never-substring ignore semantics, the settings override, default-set contents, and the async path (including coroutine marking).
- Full suite: 65 passed, 1 skipped. `ruff check`, `ruff format --check`, and `mypy` are clean on the new files (the pre-existing `harry/email` mypy/ruff findings are untouched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvJKN78Sc2RkCK5skMUUZ8)_