### PR TITLE
Add shared /health endpoint view

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,3 +674,36 @@ access_log_format = '%(h)s "%(r)s" %(s)s %(b)s %(D)sus traceparent=%({traceparen
 **Caveat:** without Caddy `tracing` (or another tracing proxy), the trace originates in
 Django — requests still trace and logs still correlate, but the proxy hop is not part of
 the trace. "One id, full lifecycle" specifically requires the proxy to participate.
+
+## Health endpoint
+
+harry ships one shared healthcheck view so "is it up, can it reach its database" is
+answered identically in every project. It's the target for an **external uptime
+monitor** — the one alert internal tooling can't provide. Wire it yourself (nothing
+registers the URL automatically):
+
+```python
+from django.urls import path
+
+from harry.views import health
+
+urlpatterns = [
+    # ...
+    path("health/", health),
+]
+```
+
+An unauthenticated `GET /health/` (no CSRF token needed) returns `200` with
+`{"status": "ok"}` when the default database answers `SELECT 1`, and `503` with
+`{"status": "error", "detail": "database unavailable"}` when it doesn't — never a
+stack trace or connection string. The check is deliberately database-only: cache,
+storage, and external-API checks make healthchecks flaky and page you for
+dependencies that have their own monitoring.
+
+Point your uptime monitor at the URL as a deployment step; expect probes every
+15–30 seconds — the view is fast and side-effect free.
+
+Healthcheck probes *do* get access lines from `RequestLogMiddleware` (the path is
+deliberately not in the default ignore set), giving you a steady status/latency
+heartbeat in SigNoz. If that's too chatty, add your health path to
+`REQUEST_LOG_IGNORE_PATHS` (see "Ignoring noise endpoints" above).

--- a/src/harry/views.py
+++ b/src/harry/views.py
@@ -1,0 +1,35 @@
+"""Shared views every production project wires the same way.
+
+Currently just the health endpoint — the target for an external uptime monitor,
+answering "is it up, can it reach its database" identically everywhere.
+"""
+
+import logging
+
+from django.db import connection
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+
+logger = logging.getLogger(__name__)
+
+
+@csrf_exempt
+def health(request: HttpRequest) -> JsonResponse:
+    """Return 200 ``{"status": "ok"}`` if the default database answers ``SELECT 1``.
+
+    Deliberately checks database connectivity only: cache/storage/external-API
+    checks make healthchecks flaky and page for dependencies that have their own
+    monitoring. No auth and no CSRF, so an uptime monitor can hit it bare; wire
+    it explicitly with ``path("health/", health)`` — nothing registers it for you.
+    """
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    except Exception:
+        # The generic detail is deliberate: connection errors carry DSNs and
+        # hostnames, and this body is served unauthenticated.
+        logger.exception("Healthcheck database connectivity failure")
+        return JsonResponse(
+            {"status": "error", "detail": "database unavailable"}, status=503
+        )
+    return JsonResponse({"status": "ok"})

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,8 @@ INSTALLED_APPS = [
     "harry.email",
 ]
 
+ROOT_URLCONF = "tests.urls"
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,72 @@
+"""Tests for the shared /health endpoint.
+
+These go through the test client and ``tests.urls`` (not ``RequestFactory``) so the
+full middleware stack — CSRF included — is exercised the way an uptime monitor
+would hit the endpoint.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+from django.db import OperationalError
+from django.test import Client
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def body(response):
+    return json.loads(response.content)
+
+
+def test_healthy_db_returns_200_ok(client):
+    response = client.get("/health/")
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/json"
+    assert body(response) == {"status": "ok"}
+
+
+def test_anonymous_access(client):
+    # No login, no session, no credentials of any kind.
+    response = client.get("/health/")
+    assert response.status_code == 200
+
+
+def test_failing_db_returns_503(client):
+    with mock.patch(
+        "harry.views.connection.cursor",
+        side_effect=OperationalError("connection failed"),
+    ):
+        response = client.get("/health/")
+    assert response.status_code == 503
+    assert response["Content-Type"] == "application/json"
+    assert body(response) == {"status": "error", "detail": "database unavailable"}
+
+
+def test_db_error_detail_is_not_leaked(client):
+    secret = 'connection to "postgres://harry:hunter2@db.internal:5432/prod" failed'
+    with mock.patch(
+        "harry.views.connection.cursor", side_effect=OperationalError(secret)
+    ):
+        response = client.get("/health/")
+    assert response.status_code == 503
+    assert "hunter2" not in response.content.decode()
+    assert "db.internal" not in response.content.decode()
+
+
+def test_unexpected_error_also_returns_503(client):
+    # Not just database errors: anything raised by the check must map to a clean 503.
+    with mock.patch("harry.views.connection.cursor", side_effect=RuntimeError("boom")):
+        response = client.get("/health/")
+    assert response.status_code == 503
+    assert body(response)["status"] == "error"
+
+
+def test_post_without_csrf_token_is_not_rejected():
+    client = Client(enforce_csrf_checks=True)
+    response = client.post("/health/")
+    assert response.status_code == 200
+    assert body(response) == {"status": "ok"}

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from harry.views import health
+
+urlpatterns = [
+    path("health/", health),
+]


### PR DESCRIPTION
Closes #7.

## What

- `harry.views.health`: a plain function view (no DRF, no auth, `@csrf_exempt`) that runs `SELECT 1` against the default database. Returns `200 {"status": "ok"}` when healthy, `503 {"status": "error", "detail": "database unavailable"}` when the check raises. The detail is deliberately generic — connection errors carry DSNs/hostnames and this body is served unauthenticated; the full exception is logged server-side instead.
- Database-only on purpose, no pluggable check registry, per the issue's design.
- Projects wire it themselves with `path("health/", health)` — no automatic URL registration.

## Tests

Added `tests/urls.py` and `ROOT_URLCONF` to the test settings so tests run through the test client and the full middleware stack (CSRF included), the way an uptime monitor would hit it:

- 200 + JSON body when the DB is reachable, anonymously
- 503 + clean JSON body when the connection raises (`OperationalError` and unexpected errors both), with an explicit test that DSN-like exception text never leaks into the response
- POST without a CSRF token is not rejected (`enforce_csrf_checks=True`)

## Docs

README gains a "Health endpoint" section: wiring the URL, pointing the uptime monitor at it as a deployment step, and the note that probes intentionally emit `RequestLogMiddleware` access lines as a status/latency heartbeat — with the `REQUEST_LOG_IGNORE_PATHS` opt-out for projects that find it too chatty.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jXwTZP98vu7EQBCor5r3z)_