### PR TITLE
Make django-anymail an optional email extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the same way.
 
 | Module | What it does | Needs |
 |---|---|---|
-| [`harry.email`](#email) | Transactional email via anymail, persisted to your database with delivery tracking | anymail + a transactional ESP |
+| [`harry.email`](#email) | Transactional email via anymail, persisted to your database with delivery tracking | the `harry[email]` extra + a transactional ESP |
 | [`harry.logconfig`](#logging) | Structured logging config: readable in development, JSON in production | nothing (stdlib only) |
 | [`harry.middleware`](#request-logging) | One structured access log line per request | nothing |
 | [`harry.views.health`](#health-endpoint) | DB-checking healthcheck endpoint | nothing |
@@ -27,11 +27,13 @@ dependencies = [
 ]
 ```
 
-If the project will use [Tracing](#tracing), install the `otel` extra instead:
+Each module's third-party dependencies ship as an extra, so a project only
+installs what it wires up: [Email](#email) needs the `email` extra,
+[Tracing](#tracing) the `otel` extra. Name what you use in the requirement:
 
 ```toml
 dependencies = [
-    "harry[otel] @ git+https://github.com/hkhanna/django-harry",
+    "harry[email,otel] @ git+https://github.com/hkhanna/django-harry",
 ]
 ```
 
@@ -41,7 +43,8 @@ Transactional email through [django-anymail](https://anymail.dev/), with every
 message persisted as an `EmailMessage` record in your database and delivery
 tracked via ESP webhooks.
 
-**Requires:** anymail and a transactional ESP account. Nothing else from harry.
+**Requires:** the `harry[email]` extra (see [Installation](#installation)) and
+a transactional ESP account. Nothing else from harry.
 
 ### Setup
 
@@ -793,7 +796,7 @@ purpose; the linked section is the source of *how*.
 
 **Email** ("[Email](#email)")
 
-- [ ] `anymail` and `harry.email` in `INSTALLED_APPS`; ESP configured via `EMAIL_BACKEND` + `ANYMAIL`
+- [ ] `harry[email]` installed; `anymail` and `harry.email` in `INSTALLED_APPS`; ESP configured via `EMAIL_BACKEND` + `ANYMAIL`
 - [ ] `SITE_CONFIG` and `MAX_SUBJECT_LENGTH` set
 - [ ] Email templates created (`*_subject.txt`, `*_message.txt`)
 - [ ] Migrations run
@@ -839,7 +842,7 @@ procedure is in [docs/observability-signoz.md](docs/observability-signoz.md))
 This project uses [uv](https://docs.astral.sh/uv/) for dependency management.
 
 ```bash
-# Install dependencies (--all-extras so the OpenTelemetry integration tests run)
+# Install dependencies (--all-extras so the email and OpenTelemetry tests run)
 uv sync --all-extras
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ dev = [
     "ruff>=0.14.1",
 ]
 
+# Migrations stay byte-for-byte as `makemigrations` writes them, so ruff neither
+# lints nor reformats them.
+[tool.ruff]
+extend-exclude = ["**/migrations"]
+
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"
 pythonpath = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,19 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "django>=5.2.7",
-    "django-anymail>=13.1",
 ]
 
+# Each module's third-party dependencies ship as an extra, so installing harry costs
+# nothing a project doesn't wire up.
+[project.optional-dependencies]
+email = [
+    "django-anymail>=13.1",
+]
 # The OpenTelemetry packages release in lockstep and occasionally break against each
 # other; this extra is the single place the compatible constellation is maintained.
 # Ranges (not exact pins) because harry is a library — hard pins would deadlock a
 # consumer's resolver. The stable packages version as 1.x, the instrumentations as
 # 0.NNbM betas; each 1.N release pairs with the 0.(N+21)b0 instrumentation release.
-[project.optional-dependencies]
 otel = [
     "opentelemetry-api>=1.43,<2",
     "opentelemetry-sdk>=1.43,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ dependencies = [
     "django>=5.2.7",
 ]
 
-# Each module's third-party dependencies ship as an extra, so installing harry costs
-# nothing a project doesn't wire up.
 [project.optional-dependencies]
 email = [
     "django-anymail>=13.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,10 @@ plugins = ["mypy_django_plugin.main"]
 module = "opentelemetry.*"
 ignore_missing_imports = true
 
+# anymail ships no py.typed marker either.
+[[tool.mypy.overrides]]
+module = "anymail.*"
+ignore_missing_imports = true
+
 [tool.django-stubs]
 django_settings_module = "tests.settings"

--- a/src/harry/email/apps.py
+++ b/src/harry/email/apps.py
@@ -2,11 +2,6 @@ import importlib.util
 
 from django.apps import AppConfig
 
-_INSTALL_HINT = (
-    "harry.email requires django-anymail, which harry does not install by default. "
-    "Install the extra: pip install 'harry[email]'"
-)
-
 
 class EmailConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -15,5 +10,9 @@ class EmailConfig(AppConfig):
 
     def ready(self):
         if importlib.util.find_spec("anymail") is None:
-            raise ImportError(_INSTALL_HINT)
+            raise ImportError(
+                "harry.email requires django-anymail, which harry does not install "
+                "by default. Install the extra: "
+                "uv add 'harry[email] @ git+https://github.com/hkhanna/django-harry'"
+            )
         import harry.email.signals  # noqa: F401

--- a/src/harry/email/apps.py
+++ b/src/harry/email/apps.py
@@ -1,4 +1,11 @@
+import importlib.util
+
 from django.apps import AppConfig
+
+_INSTALL_HINT = (
+    "harry.email requires django-anymail, which harry does not install by default. "
+    "Install the extra: pip install 'harry[email]'"
+)
 
 
 class EmailConfig(AppConfig):
@@ -7,4 +14,6 @@ class EmailConfig(AppConfig):
     verbose_name = "Harry"
 
     def ready(self):
+        if importlib.util.find_spec("anymail") is None:
+            raise ImportError(_INSTALL_HINT)
         import harry.email.signals  # noqa: F401

--- a/src/harry/email/migrations/0001_initial.py
+++ b/src/harry/email/migrations/0001_initial.py
@@ -8,6 +8,7 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+
     initial = True
 
     dependencies = [
@@ -16,148 +17,44 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name="EmailMessage",
+            name='EmailMessage',
             fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                (
-                    "uuid",
-                    models.UUIDField(
-                        default=uuid.uuid4,
-                        editable=False,
-                        help_text="Secondary ID",
-                        unique=True,
-                        verbose_name="UUID",
-                    ),
-                ),
-                (
-                    "created_at",
-                    models.DateTimeField(
-                        db_index=True, default=django.utils.timezone.now
-                    ),
-                ),
-                ("updated_at", models.DateTimeField(auto_now=True)),
-                ("sent_at", models.DateTimeField(blank=True, null=True)),
-                ("sender_name", models.CharField(blank=True, max_length=254)),
-                ("sender_email", models.EmailField(max_length=254)),
-                ("to_name", models.CharField(blank=True, max_length=254)),
-                ("to_email", models.EmailField(max_length=254)),
-                ("reply_to_name", models.CharField(blank=True, max_length=254)),
-                ("reply_to_email", models.EmailField(blank=True, max_length=254)),
-                ("subject", models.CharField(blank=True, max_length=254)),
-                ("template_prefix", models.CharField(max_length=254)),
-                ("template_context", models.JSONField(blank=True, default=dict)),
-                (
-                    "message_id",
-                    models.CharField(
-                        blank=True,
-                        default=None,
-                        help_text="Message-ID provided by the sending service as per RFC 5322",
-                        max_length=254,
-                        null=True,
-                        unique=True,
-                    ),
-                ),
-                (
-                    "status",
-                    models.CharField(
-                        choices=[
-                            ("new", "New"),
-                            ("ready", "Ready"),
-                            ("pending", "Pending"),
-                            ("accepted", "Accepted"),
-                            ("canceled", "Canceled"),
-                            ("error", "Error"),
-                            ("delivered", "Delivered"),
-                            ("rejected", "Rejected"),
-                            ("bounced", "Bounced"),
-                            ("complained", "Complained"),
-                            ("unsubscribed", "Unsubscribed"),
-                            ("opened", "Opened"),
-                            ("clicked", "Clicked"),
-                            ("unknown", "Unknown"),
-                        ],
-                        default="new",
-                        max_length=254,
-                    ),
-                ),
-                (
-                    "esp_event",
-                    models.JSONField(
-                        blank=True, default=dict, help_text="Raw ESP webhook event"
-                    ),
-                ),
-                (
-                    "esp_event_at",
-                    models.DateTimeField(
-                        blank=True,
-                        help_text="Timestamp of most recent ESP webhook received",
-                        null=True,
-                    ),
-                ),
-                ("error_message", models.TextField(blank=True)),
-                (
-                    "created_by",
-                    models.ForeignKey(
-                        blank=True,
-                        help_text="User that caused the EmailMessage to be created.",
-                        null=True,
-                        on_delete=django.db.models.deletion.SET_NULL,
-                        to=settings.AUTH_USER_MODEL,
-                    ),
-                ),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, help_text='Secondary ID', unique=True, verbose_name='UUID')),
+                ('created_at', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('sent_at', models.DateTimeField(blank=True, null=True)),
+                ('sender_name', models.CharField(blank=True, max_length=254)),
+                ('sender_email', models.EmailField(max_length=254)),
+                ('to_name', models.CharField(blank=True, max_length=254)),
+                ('to_email', models.EmailField(max_length=254)),
+                ('reply_to_name', models.CharField(blank=True, max_length=254)),
+                ('reply_to_email', models.EmailField(blank=True, max_length=254)),
+                ('subject', models.CharField(blank=True, max_length=254)),
+                ('template_prefix', models.CharField(max_length=254)),
+                ('template_context', models.JSONField(blank=True, default=dict)),
+                ('message_id', models.CharField(blank=True, default=None, help_text='Message-ID provided by the sending service as per RFC 5322', max_length=254, null=True, unique=True)),
+                ('status', models.CharField(choices=[('new', 'New'), ('ready', 'Ready'), ('pending', 'Pending'), ('accepted', 'Accepted'), ('canceled', 'Canceled'), ('error', 'Error'), ('delivered', 'Delivered'), ('rejected', 'Rejected'), ('bounced', 'Bounced'), ('complained', 'Complained'), ('unsubscribed', 'Unsubscribed'), ('opened', 'Opened'), ('clicked', 'Clicked'), ('unknown', 'Unknown')], default='new', max_length=254)),
+                ('esp_event', models.JSONField(blank=True, default=dict, help_text='Raw ESP webhook event')),
+                ('esp_event_at', models.DateTimeField(blank=True, help_text='Timestamp of most recent ESP webhook received', null=True)),
+                ('error_message', models.TextField(blank=True)),
+                ('created_by', models.ForeignKey(blank=True, help_text='User that caused the EmailMessage to be created.', null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.CreateModel(
-            name="EmailMessageAttachment",
+            name='EmailMessageAttachment',
             fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                (
-                    "uuid",
-                    models.UUIDField(
-                        default=uuid.uuid4,
-                        editable=False,
-                        help_text="Secondary ID",
-                        unique=True,
-                        verbose_name="UUID",
-                    ),
-                ),
-                (
-                    "created_at",
-                    models.DateTimeField(
-                        db_index=True, default=django.utils.timezone.now
-                    ),
-                ),
-                ("updated_at", models.DateTimeField(auto_now=True)),
-                ("file", models.FileField(upload_to="email_message_attachments/")),
-                ("filename", models.CharField(max_length=254)),
-                ("mimetype", models.CharField(max_length=254)),
-                (
-                    "email_message",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name="attachments",
-                        to="email.emailmessage",
-                    ),
-                ),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, help_text='Secondary ID', unique=True, verbose_name='UUID')),
+                ('created_at', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('file', models.FileField(upload_to='email_message_attachments/')),
+                ('filename', models.CharField(max_length=254)),
+                ('mimetype', models.CharField(max_length=254)),
+                ('email_message', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='attachments', to='email.emailmessage')),
             ],
             options={
-                "order_with_respect_to": "email_message",
+                'order_with_respect_to': 'email_message',
             },
         ),
     ]

--- a/src/harry/email/migrations/0001_initial.py
+++ b/src/harry/email/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
@@ -17,44 +16,148 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='EmailMessage',
+            name="EmailMessage",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, help_text='Secondary ID', unique=True, verbose_name='UUID')),
-                ('created_at', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('sent_at', models.DateTimeField(blank=True, null=True)),
-                ('sender_name', models.CharField(blank=True, max_length=254)),
-                ('sender_email', models.EmailField(max_length=254)),
-                ('to_name', models.CharField(blank=True, max_length=254)),
-                ('to_email', models.EmailField(max_length=254)),
-                ('reply_to_name', models.CharField(blank=True, max_length=254)),
-                ('reply_to_email', models.EmailField(blank=True, max_length=254)),
-                ('subject', models.CharField(blank=True, max_length=254)),
-                ('template_prefix', models.CharField(max_length=254)),
-                ('template_context', models.JSONField(blank=True, default=dict)),
-                ('message_id', models.CharField(blank=True, default=None, help_text='Message-ID provided by the sending service as per RFC 5322', max_length=254, null=True, unique=True)),
-                ('status', models.CharField(choices=[('new', 'New'), ('ready', 'Ready'), ('pending', 'Pending'), ('accepted', 'Accepted'), ('canceled', 'Canceled'), ('error', 'Error'), ('delivered', 'Delivered'), ('rejected', 'Rejected'), ('bounced', 'Bounced'), ('complained', 'Complained'), ('unsubscribed', 'Unsubscribed'), ('opened', 'Opened'), ('clicked', 'Clicked'), ('unknown', 'Unknown')], default='new', max_length=254)),
-                ('esp_event', models.JSONField(blank=True, default=dict, help_text='Raw ESP webhook event')),
-                ('esp_event_at', models.DateTimeField(blank=True, help_text='Timestamp of most recent ESP webhook received', null=True)),
-                ('error_message', models.TextField(blank=True)),
-                ('created_by', models.ForeignKey(blank=True, help_text='User that caused the EmailMessage to be created.', null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "uuid",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        help_text="Secondary ID",
+                        unique=True,
+                        verbose_name="UUID",
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        db_index=True, default=django.utils.timezone.now
+                    ),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("sent_at", models.DateTimeField(blank=True, null=True)),
+                ("sender_name", models.CharField(blank=True, max_length=254)),
+                ("sender_email", models.EmailField(max_length=254)),
+                ("to_name", models.CharField(blank=True, max_length=254)),
+                ("to_email", models.EmailField(max_length=254)),
+                ("reply_to_name", models.CharField(blank=True, max_length=254)),
+                ("reply_to_email", models.EmailField(blank=True, max_length=254)),
+                ("subject", models.CharField(blank=True, max_length=254)),
+                ("template_prefix", models.CharField(max_length=254)),
+                ("template_context", models.JSONField(blank=True, default=dict)),
+                (
+                    "message_id",
+                    models.CharField(
+                        blank=True,
+                        default=None,
+                        help_text="Message-ID provided by the sending service as per RFC 5322",
+                        max_length=254,
+                        null=True,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("new", "New"),
+                            ("ready", "Ready"),
+                            ("pending", "Pending"),
+                            ("accepted", "Accepted"),
+                            ("canceled", "Canceled"),
+                            ("error", "Error"),
+                            ("delivered", "Delivered"),
+                            ("rejected", "Rejected"),
+                            ("bounced", "Bounced"),
+                            ("complained", "Complained"),
+                            ("unsubscribed", "Unsubscribed"),
+                            ("opened", "Opened"),
+                            ("clicked", "Clicked"),
+                            ("unknown", "Unknown"),
+                        ],
+                        default="new",
+                        max_length=254,
+                    ),
+                ),
+                (
+                    "esp_event",
+                    models.JSONField(
+                        blank=True, default=dict, help_text="Raw ESP webhook event"
+                    ),
+                ),
+                (
+                    "esp_event_at",
+                    models.DateTimeField(
+                        blank=True,
+                        help_text="Timestamp of most recent ESP webhook received",
+                        null=True,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="User that caused the EmailMessage to be created.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='EmailMessageAttachment',
+            name="EmailMessageAttachment",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, help_text='Secondary ID', unique=True, verbose_name='UUID')),
-                ('created_at', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('file', models.FileField(upload_to='email_message_attachments/')),
-                ('filename', models.CharField(max_length=254)),
-                ('mimetype', models.CharField(max_length=254)),
-                ('email_message', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='attachments', to='email.emailmessage')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "uuid",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        help_text="Secondary ID",
+                        unique=True,
+                        verbose_name="UUID",
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        db_index=True, default=django.utils.timezone.now
+                    ),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("file", models.FileField(upload_to="email_message_attachments/")),
+                ("filename", models.CharField(max_length=254)),
+                ("mimetype", models.CharField(max_length=254)),
+                (
+                    "email_message",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="attachments",
+                        to="email.emailmessage",
+                    ),
+                ),
             ],
             options={
-                'order_with_respect_to': 'email_message',
+                "order_with_respect_to": "email_message",
             },
         ),
     ]

--- a/src/harry/email/services.py
+++ b/src/harry/email/services.py
@@ -1,7 +1,6 @@
 import logging
 import mimetypes
-import traceback
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import IO, AnyStr, List
 from uuid import uuid4
 
@@ -236,7 +235,8 @@ def email_message_send(*, email_message: EmailMessage) -> None:
         #     raise RuntimeError("GlobalSetting disable_outbound_email is True")
         else:
             django_email_message.send()
-            email_message.message_id = django_email_message.anymail_status.message_id
+            # anymail stamps anymail_status onto the message object at send time.
+            email_message.message_id = django_email_message.anymail_status.message_id  # type: ignore[attr-defined]
 
     except Exception as e:
         email_message.status = constants.EmailMessage.Status.ERROR

--- a/src/harry/observability.py
+++ b/src/harry/observability.py
@@ -26,7 +26,8 @@ __all__ = ["init_observability"]
 
 _INSTALL_HINT = (
     "init_observability() requires the OpenTelemetry packages, which harry does not "
-    "install by default. Install the extra: pip install 'harry[otel]'"
+    "install by default. Install the extra: "
+    "uv add 'harry[otel] @ git+https://github.com/hkhanna/django-harry'"
 )
 
 # Instrumentations enabled when their target library is importable. The instrumentor

--- a/uv.lock
+++ b/uv.lock
@@ -203,10 +203,12 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
-    { name = "django-anymail" },
 ]
 
 [package.optional-dependencies]
+email = [
+    { name = "django-anymail" },
+]
 otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -231,7 +233,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.7" },
-    { name = "django-anymail", specifier = ">=13.1" },
+    { name = "django-anymail", marker = "extra == 'email'", specifier = ">=13.1" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.43,<2" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.43,<2" },
     { name = "opentelemetry-instrumentation-django", marker = "extra == 'otel'", specifier = ">=0.64b0,<1" },
@@ -240,7 +242,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-requests", marker = "extra == 'otel'", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.43,<2" },
 ]
-provides-extras = ["otel"]
+provides-extras = ["email", "otel"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Move `django-anymail` from core dependencies into a new `email` extra, so plain `harry` depends only on Django — a project that skips `harry.email` installs nothing for it (mirrors the existing `otel` extra).
- `EmailConfig.ready()` now raises an `ImportError` with a `uv add` install hint when anymail is missing, following `harry.observability`'s pattern (whose hint now also points at `uv`).
- Update the README: module table, installation section (`harry[email,otel]`), the Email section's requirements, the per-project checklist, and the dev-setup note.
- Fix pre-existing lint/mypy failures the checks surfaced: unused imports in email services and a mypy override for anymail's missing `py.typed` marker. Migrations are excluded from ruff so generated files stay byte-for-byte as `makemigrations` writes them.

## Testing

- `uv run pytest` — 83 passed, 1 skipped
- `uv run mypy .` — clean
- `uv run ruff check` and `ruff format --check` — clean